### PR TITLE
Add ignore rules for iso-build.yaml

### DIFF
--- a/.github/workflows/iso-build.yaml
+++ b/.github/workflows/iso-build.yaml
@@ -2,7 +2,20 @@
 
 name: Build Arch ISO with ArchInstall Commit
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+    - '.github/**'
+    - 'docs/**'
+    - '**.editorconfig'
+    - '**.gitignore'
+    - '**.yml'
+    - '**.yaml'
+    - '**.md'
+    - '**.toml'
+    - '**.cfg'
+    - 'LICENSE'
+    - 'PKGBUILD'
 
 jobs:
   build:


### PR DESCRIPTION
# Describe your PR

This commit adds specific rules to prevent building the ISO on every PR if ignored files have been changed

**Current limitations/problems:** If some file that didn't fall under the rules was changed within the same PR and triggered the ISO build, then all new commits in this PR will trigger the ISO build, even if ignored files were changed